### PR TITLE
Update .bashrc to support very early bashrc additions

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-etc-skel/etc/skel/.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-etc-skel/etc/skel/.bashrc
@@ -2,6 +2,8 @@
 # see /usr/share/doc/bash/examples/startup-files (in the package bash-doc)
 # for examples
 
+for i in $(\ls $HOME/.bashrc.pre.d/* 2>/dev/null); do source $i; done
+
 # If not running interactively, don't do anything
 case $- in
     *i*) ;;


### PR DESCRIPTION
Me and my small little additions that nobody cares but me :)

So, I am using my newly created addon: https://github.com/hanoii/ddev-sshd

I was trying to make sure I was on /var/www/html sshing to it. I am working into adding a bashrc.d addition that `cd /var/www/html`. It obviously works normally, however, running:

`ssh project.ddev.site ls` it doesn't. The reason is that the default bashrc default prevents this from happening (note, this is not a turly non-interactive shell, bashrc is being actually sourced). 

So I thought of a way to add something that I could plug before the check and came up with this small tweak. Wonder if you'd consider it. Obviously I could live without it, but I don't think it adds complexity and ands even more tweaking.